### PR TITLE
Use ymkan oath list for listing slot names

### DIFF
--- a/list.go
+++ b/list.go
@@ -12,7 +12,7 @@ import (
 // List returns all currently configured OATH slot names
 func List() ([]string, error) {
 
-	cmd := exec.Command("ykman", "oath", "code")
+	cmd := exec.Command("ykman", "oath", "list")
 
 	output, err := cmd.CombinedOutput()
 
@@ -48,7 +48,7 @@ func parseList(body string, err error) ([]string, error) {
 	names := make([]string, len(lines))
 
 	for index, line := range lines {
-		chunks := strings.Split(line, " ")
+		chunks := strings.Split(line, "\n")
 		names[index] = chunks[0]
 	}
 

--- a/list.go
+++ b/list.go
@@ -6,7 +6,6 @@ package ykman
 
 import (
 	"os/exec"
-	"strings"
 )
 
 // List returns all currently configured OATH slot names
@@ -45,12 +44,5 @@ func parseList(body string, err error) ([]string, error) {
 		return nil, err
 	}
 
-	names := make([]string, len(lines))
-
-	for index, line := range lines {
-		chunks := strings.Split(line, "\n")
-		names[index] = chunks[0]
-	}
-
-	return names, nil
+	return lines, nil
 }

--- a/list_test.go
+++ b/list_test.go
@@ -36,6 +36,13 @@ func TestListParse(t *testing.T) {
 			expectedNames: []string{"aws"},
 		},
 		{
+			title: "single result with spaces",
+			body: `
+				aws main account
+			`,
+			expectedNames: []string{"aws main account"},
+		},
+		{
 			title: "multiple results",
 			body: `
 				aws
@@ -45,29 +52,13 @@ func TestListParse(t *testing.T) {
 			expectedNames: []string{"aws", "aws-cn", "aws-us-gov"},
 		},
 		{
-			title: "single result with touch",
-			body: `
-				aws         [Touch Credential]
-			`,
-			expectedNames: []string{"aws"},
-		},
-		{
-			title: "multiple results with touch",
-			body: `
-				aws         [Touch Credential]
-				aws-cn      [Touch Credential]
-				aws-us-gov  [Touch Credential]
-			`,
-			expectedNames: []string{"aws", "aws-cn", "aws-us-gov"},
-		},
-		{
-			title: "multiple results some with touch",
+			title: "multiple results with spaces",
 			body: `
 				aws
-				aws-cn      [Touch Credential]
-				aws-us-gov
+				aws-cn
+				aws main account
 			`,
-			expectedNames: []string{"aws", "aws-cn", "aws-us-gov"},
+			expectedNames: []string{"aws", "aws-cn", "aws main account"},
 		},
 		{
 			title: "ykman executable missing",


### PR DESCRIPTION
ykman has a list command to list available OATH slots. OATH slot
names can also have spaces in the name.